### PR TITLE
Add an exception handler to output 'exit 1' for eval

### DIFF
--- a/bin/decrypt-kms-env
+++ b/bin/decrypt-kms-env
@@ -40,5 +40,10 @@ if (!module.parent) {
     if (err) throw err;
     console.log(output);
   });
+  process.on('uncaughtException', function(err) {
+    console.warn(err.toString());
+    console.log('exit 1;');
+    process.exit(1);
+  });
 }
 

--- a/bin/decrypt-kms-env
+++ b/bin/decrypt-kms-env
@@ -36,14 +36,14 @@ function decrypt(env, callback) {
 }
 
 if (!module.parent) {
-  decrypt(process.env, function(err, output) {
-    if (err) throw err;
-    console.log(output);
-  });
   process.on('uncaughtException', function(err) {
     console.warn(err.toString());
     console.log('exit 1;');
     process.exit(1);
+  });
+  decrypt(process.env, function(err, output) {
+    if (err) throw err;
+    console.log(output);
   });
 }
 


### PR DESCRIPTION
Not the most elegant approach but might work as a stopgap for now.

Might have to switch back to the sources approach instead of eval (e.g. `. decrypt-kms-env`) and use a `sh` script wrapper around node.

Will test this out before merging+releasing.

cc @emilymcafee 
