### PR TITLE
Escape decrypted shell vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function sh(env, callback) {
     if (err) return callback(err);
     var output = '';
     decrypted.forEach(function(data) {
-      output += util.format('export %s=%s; ', data.key, data.decrypted);
+      output += util.format('export %s=\'%s\'; ', data.key, data.decrypted);
       output += util.format('echo \'Decrypted %s=%s\'; ', data.key, scrub(data.decrypted));
     });
     callback(null, output);

--- a/test/decrypt-kms-env.test.js
+++ b/test/decrypt-kms-env.test.js
@@ -35,7 +35,7 @@ tape('decrypt-kms-env: secure env vars', function(assert) {
     NormalVarC: 'Hello World'
   }, function(err, output) {
     assert.ifError(err, 'no error');
-    assert.deepEqual(output, 'export SecureVarA=DecryptedValue1; echo \'Decrypted SecureVarA=************lue1\'; export SecureVarB=DecryptedValue2; echo \'Decrypted SecureVarB=************lue2\'; ', 'shell output');
+    assert.deepEqual(output, 'export SecureVarA=\'DecryptedValue1\'; echo \'Decrypted SecureVarA=************lue1\'; export SecureVarB=\'DecryptedValue2\'; echo \'Decrypted SecureVarB=************lue2\'; ', 'shell output');
     assert.end();
   });
 });


### PR DESCRIPTION
Currently, if a secret value is added that contains redirects, pipes, or other operators, then

```Dockerfile
RUN eval $(./node_modules/.bin/decrypt-kms-env) && npm start
```

will produce unexpected results. With this PR, the secrets will be escaped, so even secrets containing `>` , `|` and friends can be decrypted and used with the quick-eval method.