### PR TITLE
Update all dependencies, remove Node 4 engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
-node_js: 4
-
+node_js:
+- 6
+- 8

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   },
   "homepage": "https://github.com/mapbox/decrypt-kms-env",
   "dependencies": {
-    "aws-sdk": "^2.5.0",
-    "d3-queue": "^3.0.2"
+    "aws-sdk": "^2.292.0",
+    "d3-queue": "^3.0.7"
   },
   "devDependencies": {
-    "aws-sdk-mock": "^1.4.1",
-    "tape": "^4.6.0"
+    "aws-sdk-mock": "^4.1.0",
+    "tape": "^4.9.1"
   }
 }


### PR DESCRIPTION
Addressing issues in https://github.com/mapbox/decrypt-kms-env/issues/9, updates all dependencies and removes the Node 4 engine from the `travis.yml` in favor of testing on 6 and 8.

/cc @mapbox/assembly-line 