### PR TITLE
Revise the README to recommend 1.x usage in Dockerfile

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,35 +4,51 @@
 
 Simple utility for decrypting secure environment variables encrypted using KMS.
 
-### Install
-
-`npm install @mapbox/decrypt-kms-env --save`
+## Usage
 
 ### From a Dockerfile/shell
 
-Once installed, run your application in your Dockerfile prefixed:
+**Use v1.x** when you need to decrypt secure environment variables in a Dockerfile or shell script. In a failure situation, such as an with an incorrectly encrypted environment variable, this method will result in the process exiting with a non-zero exit code.
 
+This method follows a simple convention whereby:
+
+- Encrypted environment variable blobs are prefixed with `secure:` (e.g., `MySecretVar=secure:abcde1234`),
+- Values are decrypted in-place. Scrubbed debug output is provided so you can confirm env vars have been decrypted and set.
+
+#### Example usage in a Dockerfile:
+
+```dockerfile
+# Install
+RUN curl -sL https://github.com/mapbox/decrypt-kms-env/archive/v1.0.6.tar.gz | tar --gunzip --extract --strip-components=1 --exclude=readme.md --directory=/usr/local
+
+# Decrypt vars and start app
+RUN . decrypt-kms-env && \
+    npm start
 ```
-RUN eval $(./node_modules/.bin/decrypt-kms-env) && npm start
-```
 
-Follows a simple convention whereby:
+#### Example Shell usage:
 
-- Encrypted blobs are prefixed with `secure:`,
-- When the output of `decrypt-kms-env` is passed to `eval` in a shell, values are decrypted in-place. Scrubbed debug output is provided so you can confirm env vars have been decrypted and set.
-
-```
-> eval $(./node_modules/.bin/decrypt-kms-env)
+```sh
+> . decrypt-kms-env
 Decrypted SecureValueA=************1231
 Decrypted SecureValueB=************913X
 ```
 
-### From JS/Lambda function
+### From JavaScript/Lambda function
 
-If you don't have access to a shell to set env vars before starting your app, you can run `decrypt-kms-env` via JS.
+**Use v3.x**. If you don't have access to a shell to set env vars before starting your app, you can run `decrypt-kms-env` via JS.
+
+Install:
+
+```sh
+npm install @mapbox/decrypt-kms-env --save
+```
+
+Use in JS:
 
 ```js
 var dke = require('@mapbox/decrypt-kms-env');
+
 dke(process.env, function(err, scrubbed) {
   if (err) throw err;
   // Values in process.env are now decrypted.
@@ -41,24 +57,3 @@ dke(process.env, function(err, scrubbed) {
   // console.log(scrubbed);
 });
 ```
-
-------
-
-### Our usage
-
-We use this from within Docker containers to decrypt env vars encrypted via KMS.
-
-------
-
-### v1.x
-
-For projects using `python` & `awscli` rather than node, the `v1.x` branch of this project can be used.
-
-```sh
-# Install
-curl -sL https://github.com/mapbox/decrypt-kms-env/archive/v1.0.6.tar.gz | tar --gunzip --extract --strip-components=1 --exclude=readme.md --directory=/usr/local
-
-# Run app
-. decrypt-kms-env && npm start
-```
-


### PR DESCRIPTION
Updates and slightly reorganizes the README to recommend using the `1.x` version of `decrypt-kms-env` in Dockerfiles/shell.